### PR TITLE
feat: update C API bindings to MaaFramework v5.6.0

### DIFF
--- a/docs/articles/overview-of-wrapper-and-api.md
+++ b/docs/articles/overview-of-wrapper-and-api.md
@@ -348,6 +348,7 @@ IMaaDisposable Derived:
 | Wrapper | Native API |
 | --- | --- |
 | MaaAgentClient.Create() | `MaaAgentClientCreateV2` |
+| MaaAgentClient.CreateTcp() | `MaaAgentClientCreateTcp` |
 | IDisposable.Dispose() | `MaaAgentClientDestroy` |
 | IMaaAgentClient.Id | `MaaAgentClientIdentifier` |
 | IMaaAgentClient.Tasker | `MaaAgentClientRegisterTaskerSink` |

--- a/docs/articles/overview-of-wrapper-and-api.md
+++ b/docs/articles/overview-of-wrapper-and-api.md
@@ -184,6 +184,7 @@ IMaaDisposable Derived:
 | IMaaContext.RunAction() | `MaaContextRunAction` |
 | IMaaContext.RunRecognitionDirect() | `MaaContextRunRecognitionDirect` |
 | IMaaContext.RunActionDirect() | `MaaContextRunActionDirect` |
+| IMaaContext.WaitFreezes() | `MaaContextWaitFreezes` |
 | IMaaContext.OverridePipeline() | `MaaContextOverridePipeline` |
 | IMaaContext.OverrideNext() | `MaaContextOverrideNext` |
 | IMaaContext.OverrideImage() | `MaaContextOverrideImage` |

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Maa.AgentBinary" Version="1.2.0" />
-    <PackageVersion Include="Maa.Framework.Runtimes" Version="5.4.3" />
+    <PackageVersion Include="Maa.Framework.Runtimes" Version="5.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" Condition="'$(TargetFramework)' != 'net7.0'" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.10.2" />

--- a/src/MaaFramework.Binding.Native/Interop/AgentClient/MaaAgentClientAPI.cs
+++ b/src/MaaFramework.Binding.Native/Interop/AgentClient/MaaAgentClientAPI.cs
@@ -21,6 +21,9 @@ public static partial class MaaAgentClient
     public static partial MaaAgentClientHandle MaaAgentClientCreateV2(MaaStringBufferHandle identifier);
 
     [LibraryImport("MaaAgentClient", StringMarshalling = StringMarshalling.Utf8)]
+    public static partial MaaAgentClientHandle MaaAgentClientCreateTcp(ushort port);
+
+    [LibraryImport("MaaAgentClient", StringMarshalling = StringMarshalling.Utf8)]
     public static partial void MaaAgentClientDestroy(MaaAgentClientHandle client);
 
     [LibraryImport("MaaAgentClient", StringMarshalling = StringMarshalling.Utf8)]

--- a/src/MaaFramework.Binding.Native/Interop/Framework/Instance/MaaContext.cs
+++ b/src/MaaFramework.Binding.Native/Interop/Framework/Instance/MaaContext.cs
@@ -51,6 +51,10 @@ public static partial class MaaContext
 
     [LibraryImport("MaaFramework", StringMarshalling = StringMarshalling.Utf8)]
     [return: MarshalAs(UnmanagedType.U1)]
+    public static partial bool MaaContextWaitFreezes(MaaContextHandle context, MaaSize time, MaaRectHandle roi, string waitFreezesParam);
+
+    [LibraryImport("MaaFramework", StringMarshalling = StringMarshalling.Utf8)]
+    [return: MarshalAs(UnmanagedType.U1)]
     public static partial bool MaaContextOverridePipeline(MaaContextHandle context, string pipelineOverride);
 
     [LibraryImport("MaaFramework", StringMarshalling = StringMarshalling.Utf8)]

--- a/src/MaaFramework.Binding.Native/MaaContext.cs
+++ b/src/MaaFramework.Binding.Native/MaaContext.cs
@@ -159,6 +159,28 @@ public class MaaContext : IMaaContext<MaaContextHandle>, IEquatable<MaaContext>,
     }
 
     /// <inheritdoc/>
+    public bool WaitFreezes(TimeSpan time, IMaaRectBuffer recognitionBox, [StringSyntax("Json")] string waitFreezesParam = "{}")
+        => WaitFreezes((MaaSize)time.TotalMilliseconds, (MaaRectBuffer)recognitionBox, waitFreezesParam);
+
+    /// <inheritdoc cref="IMaaContext.WaitFreezes(TimeSpan, IMaaRectBuffer, string)"/>
+    public bool WaitFreezes(TimeSpan time, MaaRectBuffer recognitionBox, [StringSyntax("Json")] string waitFreezesParam = "{}")
+        => WaitFreezes((MaaSize)time.TotalMilliseconds, recognitionBox, waitFreezesParam);
+
+    /// <inheritdoc/>
+    public bool WaitFreezes(MaaSize millisecondsTime, IMaaRectBuffer recognitionBox, [StringSyntax("Json")] string waitFreezesParam = "{}")
+        => WaitFreezes(millisecondsTime, (MaaRectBuffer)recognitionBox, waitFreezesParam);
+
+    /// <inheritdoc cref="IMaaContext.WaitFreezes(MaaSize, IMaaRectBuffer, string)"/>
+    /// <remarks>
+    ///     Wrapper of <see cref="MaaContextWaitFreezes"/>.
+    /// </remarks>
+    public bool WaitFreezes(MaaSize millisecondsTime, MaaRectBuffer recognitionBox, [StringSyntax("Json")] string waitFreezesParam = "{}")
+    {
+        ArgumentNullException.ThrowIfNull(recognitionBox);
+        return MaaContextWaitFreezes(Handle, millisecondsTime, recognitionBox.Handle, waitFreezesParam);
+    }
+
+    /// <inheritdoc/>
     /// <remarks>
     ///     Wrapper of <see cref="MaaContextOverridePipeline"/>.
     /// </remarks>

--- a/src/MaaFramework.Binding.UnitTests/packages.lock.json
+++ b/src/MaaFramework.Binding.UnitTests/packages.lock.json
@@ -45,33 +45,33 @@
       },
       "Maa.Framework.Runtime.linux-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "7/kz+d9T0ikDtLaF+2bU1PuK8xllKD1j8QgXHt0rfDiPzwT81dpIWqDdSahPC91HaDQT1Ia2EEIQA8AWuHlNiQ=="
+        "resolved": "5.6.0",
+        "contentHash": "WkHvm/NwCPXNu79049RC67aYTfyyQ7NejJWCKac7Tv8OB28DAbGbAovqOKHPxKP2GM8f37EJyE4Sur32DMB8ZA=="
       },
       "Maa.Framework.Runtime.linux-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "QG4zc+ufmZ5ur+XCargNVcQS8iPgLSSIIiEZ7IVLiPJVoux79al7flmrqDX0q9vIVt1Lu4ch81cBuql8pHLRNQ=="
+        "resolved": "5.6.0",
+        "contentHash": "5C761AldXHPliilRMMmXA3c9ojxYhtIvFZ21RYBuT9E3tVQUO51WIVfHpDpyArvoaSMKfe/qXZNG4toeE9K/Qw=="
       },
       "Maa.Framework.Runtime.osx-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "ehuruYY/P2cEdJGJTIeHN+HoamBdHYitBr95ycsou9ZViE6m+B1nSkOXbJkRx8TBhS7lXx8Ac9gg7B8DT1C/Aw=="
+        "resolved": "5.6.0",
+        "contentHash": "tMr6B3uNlD/dbjfC8Ac9VQWE2xJfTHQyqAIyD5HWxam6qiFjcsa1JVj53gMhf9d8+HXjx1iSmCIVIP57Mvxw4w=="
       },
       "Maa.Framework.Runtime.osx-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "izClNttn4fk3/DL2ghhsTUd54IVmPICG9Y8vTgz53NCWseUaCdnHc7wfTQzAc7M2pKg/VAJgAdpnlOnASdR3nA=="
+        "resolved": "5.6.0",
+        "contentHash": "DJFamv6Xd3DgGQg/Oig6iBLLwFVpK38Dp50CnKR7WdppnC08tq57wQuykqQOapUm/oGmLRgO8O2mlOSGcUSWkg=="
       },
       "Maa.Framework.Runtime.win-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "72VOu72hShs5M2Jb13jEs5ZXHhs7otRPYVbZU9oHq5jOstiLfILoqOo8FNTml+mR1/zdaKws8ftEymBOKwJ0fg=="
+        "resolved": "5.6.0",
+        "contentHash": "vkANhfQVJJohKjgHWrFa32WDlL6OrahmvZaFquH+kvuSxihfNDS5E578iEPp012eH5DAtZYnE/KegPwcY7zuQw=="
       },
       "Maa.Framework.Runtime.win-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "y1BhwWDbpO5vDdMnUhXCkEPx/qmu30xHtSZVoUovnNR1IWuLuf5RP78SC9HoXcnQh67V2xc9BVoLFdOkCPJecA=="
+        "resolved": "5.6.0",
+        "contentHash": "kF8895AF7im/WjsHXFUORhWub7kW4YxfS6yQ782O+YcKnTW4kYhWW2ZT4WtDI4M3SH8bcyTI5gyrZZUk7fTN2g=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -174,7 +174,7 @@
         "type": "Project",
         "dependencies": {
           "Maa.Framework.Native": "[1.0.0-dev, )",
-          "Maa.Framework.Runtimes": "[5.4.3, )"
+          "Maa.Framework.Runtimes": "[5.6.0, )"
         }
       },
       "Maa.Framework.Binding": {
@@ -207,16 +207,16 @@
       },
       "Maa.Framework.Runtimes": {
         "type": "CentralTransitive",
-        "requested": "[5.4.3, )",
-        "resolved": "5.4.3",
-        "contentHash": "HeT3XNrReFoSb+wh5HJLyBFs4ESjLzO4i42BMjsjscwQUv9NDE+dj1Vkw4nFfA7lftpKWMivg+w5wGL9vA1nhw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "tudf2vMWH5KRGLVn+j9T6eaK1cRhjtANGnzGOaIu/v7BzDAeyaoqxJPd8DMd7FtdZNfT/6Q13j250CbuoArdag==",
         "dependencies": {
-          "Maa.Framework.Runtime.linux-arm64": "5.4.3",
-          "Maa.Framework.Runtime.linux-x64": "5.4.3",
-          "Maa.Framework.Runtime.osx-arm64": "5.4.3",
-          "Maa.Framework.Runtime.osx-x64": "5.4.3",
-          "Maa.Framework.Runtime.win-arm64": "5.4.3",
-          "Maa.Framework.Runtime.win-x64": "5.4.3"
+          "Maa.Framework.Runtime.linux-arm64": "5.6.0",
+          "Maa.Framework.Runtime.linux-x64": "5.6.0",
+          "Maa.Framework.Runtime.osx-arm64": "5.6.0",
+          "Maa.Framework.Runtime.osx-x64": "5.6.0",
+          "Maa.Framework.Runtime.win-arm64": "5.6.0",
+          "Maa.Framework.Runtime.win-x64": "5.6.0"
         }
       }
     },
@@ -264,33 +264,33 @@
       },
       "Maa.Framework.Runtime.linux-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "7/kz+d9T0ikDtLaF+2bU1PuK8xllKD1j8QgXHt0rfDiPzwT81dpIWqDdSahPC91HaDQT1Ia2EEIQA8AWuHlNiQ=="
+        "resolved": "5.6.0",
+        "contentHash": "WkHvm/NwCPXNu79049RC67aYTfyyQ7NejJWCKac7Tv8OB28DAbGbAovqOKHPxKP2GM8f37EJyE4Sur32DMB8ZA=="
       },
       "Maa.Framework.Runtime.linux-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "QG4zc+ufmZ5ur+XCargNVcQS8iPgLSSIIiEZ7IVLiPJVoux79al7flmrqDX0q9vIVt1Lu4ch81cBuql8pHLRNQ=="
+        "resolved": "5.6.0",
+        "contentHash": "5C761AldXHPliilRMMmXA3c9ojxYhtIvFZ21RYBuT9E3tVQUO51WIVfHpDpyArvoaSMKfe/qXZNG4toeE9K/Qw=="
       },
       "Maa.Framework.Runtime.osx-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "ehuruYY/P2cEdJGJTIeHN+HoamBdHYitBr95ycsou9ZViE6m+B1nSkOXbJkRx8TBhS7lXx8Ac9gg7B8DT1C/Aw=="
+        "resolved": "5.6.0",
+        "contentHash": "tMr6B3uNlD/dbjfC8Ac9VQWE2xJfTHQyqAIyD5HWxam6qiFjcsa1JVj53gMhf9d8+HXjx1iSmCIVIP57Mvxw4w=="
       },
       "Maa.Framework.Runtime.osx-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "izClNttn4fk3/DL2ghhsTUd54IVmPICG9Y8vTgz53NCWseUaCdnHc7wfTQzAc7M2pKg/VAJgAdpnlOnASdR3nA=="
+        "resolved": "5.6.0",
+        "contentHash": "DJFamv6Xd3DgGQg/Oig6iBLLwFVpK38Dp50CnKR7WdppnC08tq57wQuykqQOapUm/oGmLRgO8O2mlOSGcUSWkg=="
       },
       "Maa.Framework.Runtime.win-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "72VOu72hShs5M2Jb13jEs5ZXHhs7otRPYVbZU9oHq5jOstiLfILoqOo8FNTml+mR1/zdaKws8ftEymBOKwJ0fg=="
+        "resolved": "5.6.0",
+        "contentHash": "vkANhfQVJJohKjgHWrFa32WDlL6OrahmvZaFquH+kvuSxihfNDS5E578iEPp012eH5DAtZYnE/KegPwcY7zuQw=="
       },
       "Maa.Framework.Runtime.win-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "y1BhwWDbpO5vDdMnUhXCkEPx/qmu30xHtSZVoUovnNR1IWuLuf5RP78SC9HoXcnQh67V2xc9BVoLFdOkCPJecA=="
+        "resolved": "5.6.0",
+        "contentHash": "kF8895AF7im/WjsHXFUORhWub7kW4YxfS6yQ782O+YcKnTW4kYhWW2ZT4WtDI4M3SH8bcyTI5gyrZZUk7fTN2g=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -401,7 +401,7 @@
         "type": "Project",
         "dependencies": {
           "Maa.Framework.Native": "[1.0.0-dev, )",
-          "Maa.Framework.Runtimes": "[5.4.3, )"
+          "Maa.Framework.Runtimes": "[5.6.0, )"
         }
       },
       "Maa.Framework.Binding": {
@@ -434,16 +434,16 @@
       },
       "Maa.Framework.Runtimes": {
         "type": "CentralTransitive",
-        "requested": "[5.4.3, )",
-        "resolved": "5.4.3",
-        "contentHash": "HeT3XNrReFoSb+wh5HJLyBFs4ESjLzO4i42BMjsjscwQUv9NDE+dj1Vkw4nFfA7lftpKWMivg+w5wGL9vA1nhw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "tudf2vMWH5KRGLVn+j9T6eaK1cRhjtANGnzGOaIu/v7BzDAeyaoqxJPd8DMd7FtdZNfT/6Q13j250CbuoArdag==",
         "dependencies": {
-          "Maa.Framework.Runtime.linux-arm64": "5.4.3",
-          "Maa.Framework.Runtime.linux-x64": "5.4.3",
-          "Maa.Framework.Runtime.osx-arm64": "5.4.3",
-          "Maa.Framework.Runtime.osx-x64": "5.4.3",
-          "Maa.Framework.Runtime.win-arm64": "5.4.3",
-          "Maa.Framework.Runtime.win-x64": "5.4.3"
+          "Maa.Framework.Runtime.linux-arm64": "5.6.0",
+          "Maa.Framework.Runtime.linux-x64": "5.6.0",
+          "Maa.Framework.Runtime.osx-arm64": "5.6.0",
+          "Maa.Framework.Runtime.osx-x64": "5.6.0",
+          "Maa.Framework.Runtime.win-arm64": "5.6.0",
+          "Maa.Framework.Runtime.win-x64": "5.6.0"
         }
       }
     }

--- a/src/MaaFramework.Binding/IMaaContext.cs
+++ b/src/MaaFramework.Binding/IMaaContext.cs
@@ -77,6 +77,29 @@ public interface IMaaContext : ICloneable
     ActionDetail? RunActionDirect(string type, [StringSyntax("Json")] string param, IMaaRectBuffer recognitionBox, [StringSyntax("Json")] string recognitionDetail = "");
 
     /// <summary>
+    ///     Waits for screen to stabilize (freeze).
+    /// </summary>
+    /// <param name="millisecondsTime">The wait time in milliseconds.</param>
+    /// <param name="recognitionBox">The recognition hit box, used when target is Self to calculate ROI.</param>
+    /// <param name="waitFreezesParam">The wait parameters.<para>Supports time, target, target_offset, threshold, method, rate_limit, timeout.</para></param>
+    /// <returns><see langword="true"/> if the operation was executed successfully; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    ///     <paramref name="millisecondsTime"/> and <paramref name="waitFreezesParam"/>.time are mutually exclusive.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"/>
+    bool WaitFreezes(MaaSize millisecondsTime, IMaaRectBuffer recognitionBox, [StringSyntax("Json")] string waitFreezesParam = "{}");
+
+    /// <param name="time">The wait time.</param>
+    /// <param name="recognitionBox">The recognition hit box, used when target is Self to calculate ROI.</param>
+    /// <param name="waitFreezesParam">The wait parameters.<para>Supports time, target, target_offset, threshold, method, rate_limit, timeout.</para></param>
+    /// <remarks>
+    ///     <paramref name="time"/> and <paramref name="waitFreezesParam"/>.time are mutually exclusive.
+    /// </remarks>
+    /// <inheritdoc cref="WaitFreezes(ulong, IMaaRectBuffer, string)"/>
+    /// <exception cref="ArgumentNullException"/>
+    bool WaitFreezes(TimeSpan time, IMaaRectBuffer recognitionBox, [StringSyntax("Json")] string waitFreezesParam = "{}");
+
+    /// <summary>
     ///     Overrides a pipeline.
     /// </summary>
     /// <param name="pipelineOverride">The json used to override the pipeline.</param>

--- a/src/MaaFramework.Binding/MaaMsg.cs
+++ b/src/MaaFramework.Binding/MaaMsg.cs
@@ -12,7 +12,7 @@
 
 namespace MaaFramework.Binding.Notification;
 
-// MaaApiDocument _version: (main) v5.4.3
+// MaaApiDocument _version: (main) v5.6.0
 /// <summary>
 ///  A callback consists of a message and a payload.
 ///  The message is a string that indicates the type of the message.

--- a/src/MaaFramework/packages.lock.json
+++ b/src/MaaFramework/packages.lock.json
@@ -4,16 +4,16 @@
     "net7.0": {
       "Maa.Framework.Runtimes": {
         "type": "Direct",
-        "requested": "[5.4.3, )",
-        "resolved": "5.4.3",
-        "contentHash": "HeT3XNrReFoSb+wh5HJLyBFs4ESjLzO4i42BMjsjscwQUv9NDE+dj1Vkw4nFfA7lftpKWMivg+w5wGL9vA1nhw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "tudf2vMWH5KRGLVn+j9T6eaK1cRhjtANGnzGOaIu/v7BzDAeyaoqxJPd8DMd7FtdZNfT/6Q13j250CbuoArdag==",
         "dependencies": {
-          "Maa.Framework.Runtime.linux-arm64": "5.4.3",
-          "Maa.Framework.Runtime.linux-x64": "5.4.3",
-          "Maa.Framework.Runtime.osx-arm64": "5.4.3",
-          "Maa.Framework.Runtime.osx-x64": "5.4.3",
-          "Maa.Framework.Runtime.win-arm64": "5.4.3",
-          "Maa.Framework.Runtime.win-x64": "5.4.3"
+          "Maa.Framework.Runtime.linux-arm64": "5.6.0",
+          "Maa.Framework.Runtime.linux-x64": "5.6.0",
+          "Maa.Framework.Runtime.osx-arm64": "5.6.0",
+          "Maa.Framework.Runtime.osx-x64": "5.6.0",
+          "Maa.Framework.Runtime.win-arm64": "5.6.0",
+          "Maa.Framework.Runtime.win-x64": "5.6.0"
         }
       },
       "SonarAnalyzer.CSharp": {
@@ -24,33 +24,33 @@
       },
       "Maa.Framework.Runtime.linux-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "7/kz+d9T0ikDtLaF+2bU1PuK8xllKD1j8QgXHt0rfDiPzwT81dpIWqDdSahPC91HaDQT1Ia2EEIQA8AWuHlNiQ=="
+        "resolved": "5.6.0",
+        "contentHash": "WkHvm/NwCPXNu79049RC67aYTfyyQ7NejJWCKac7Tv8OB28DAbGbAovqOKHPxKP2GM8f37EJyE4Sur32DMB8ZA=="
       },
       "Maa.Framework.Runtime.linux-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "QG4zc+ufmZ5ur+XCargNVcQS8iPgLSSIIiEZ7IVLiPJVoux79al7flmrqDX0q9vIVt1Lu4ch81cBuql8pHLRNQ=="
+        "resolved": "5.6.0",
+        "contentHash": "5C761AldXHPliilRMMmXA3c9ojxYhtIvFZ21RYBuT9E3tVQUO51WIVfHpDpyArvoaSMKfe/qXZNG4toeE9K/Qw=="
       },
       "Maa.Framework.Runtime.osx-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "ehuruYY/P2cEdJGJTIeHN+HoamBdHYitBr95ycsou9ZViE6m+B1nSkOXbJkRx8TBhS7lXx8Ac9gg7B8DT1C/Aw=="
+        "resolved": "5.6.0",
+        "contentHash": "tMr6B3uNlD/dbjfC8Ac9VQWE2xJfTHQyqAIyD5HWxam6qiFjcsa1JVj53gMhf9d8+HXjx1iSmCIVIP57Mvxw4w=="
       },
       "Maa.Framework.Runtime.osx-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "izClNttn4fk3/DL2ghhsTUd54IVmPICG9Y8vTgz53NCWseUaCdnHc7wfTQzAc7M2pKg/VAJgAdpnlOnASdR3nA=="
+        "resolved": "5.6.0",
+        "contentHash": "DJFamv6Xd3DgGQg/Oig6iBLLwFVpK38Dp50CnKR7WdppnC08tq57wQuykqQOapUm/oGmLRgO8O2mlOSGcUSWkg=="
       },
       "Maa.Framework.Runtime.win-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "72VOu72hShs5M2Jb13jEs5ZXHhs7otRPYVbZU9oHq5jOstiLfILoqOo8FNTml+mR1/zdaKws8ftEymBOKwJ0fg=="
+        "resolved": "5.6.0",
+        "contentHash": "vkANhfQVJJohKjgHWrFa32WDlL6OrahmvZaFquH+kvuSxihfNDS5E578iEPp012eH5DAtZYnE/KegPwcY7zuQw=="
       },
       "Maa.Framework.Runtime.win-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "y1BhwWDbpO5vDdMnUhXCkEPx/qmu30xHtSZVoUovnNR1IWuLuf5RP78SC9HoXcnQh67V2xc9BVoLFdOkCPJecA=="
+        "resolved": "5.6.0",
+        "contentHash": "kF8895AF7im/WjsHXFUORhWub7kW4YxfS6yQ782O+YcKnTW4kYhWW2ZT4WtDI4M3SH8bcyTI5gyrZZUk7fTN2g=="
       },
       "Maa.Framework.Binding": {
         "type": "Project"
@@ -78,16 +78,16 @@
     "net9.0": {
       "Maa.Framework.Runtimes": {
         "type": "Direct",
-        "requested": "[5.4.3, )",
-        "resolved": "5.4.3",
-        "contentHash": "HeT3XNrReFoSb+wh5HJLyBFs4ESjLzO4i42BMjsjscwQUv9NDE+dj1Vkw4nFfA7lftpKWMivg+w5wGL9vA1nhw==",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "tudf2vMWH5KRGLVn+j9T6eaK1cRhjtANGnzGOaIu/v7BzDAeyaoqxJPd8DMd7FtdZNfT/6Q13j250CbuoArdag==",
         "dependencies": {
-          "Maa.Framework.Runtime.linux-arm64": "5.4.3",
-          "Maa.Framework.Runtime.linux-x64": "5.4.3",
-          "Maa.Framework.Runtime.osx-arm64": "5.4.3",
-          "Maa.Framework.Runtime.osx-x64": "5.4.3",
-          "Maa.Framework.Runtime.win-arm64": "5.4.3",
-          "Maa.Framework.Runtime.win-x64": "5.4.3"
+          "Maa.Framework.Runtime.linux-arm64": "5.6.0",
+          "Maa.Framework.Runtime.linux-x64": "5.6.0",
+          "Maa.Framework.Runtime.osx-arm64": "5.6.0",
+          "Maa.Framework.Runtime.osx-x64": "5.6.0",
+          "Maa.Framework.Runtime.win-arm64": "5.6.0",
+          "Maa.Framework.Runtime.win-x64": "5.6.0"
         }
       },
       "SonarAnalyzer.CSharp": {
@@ -98,33 +98,33 @@
       },
       "Maa.Framework.Runtime.linux-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "7/kz+d9T0ikDtLaF+2bU1PuK8xllKD1j8QgXHt0rfDiPzwT81dpIWqDdSahPC91HaDQT1Ia2EEIQA8AWuHlNiQ=="
+        "resolved": "5.6.0",
+        "contentHash": "WkHvm/NwCPXNu79049RC67aYTfyyQ7NejJWCKac7Tv8OB28DAbGbAovqOKHPxKP2GM8f37EJyE4Sur32DMB8ZA=="
       },
       "Maa.Framework.Runtime.linux-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "QG4zc+ufmZ5ur+XCargNVcQS8iPgLSSIIiEZ7IVLiPJVoux79al7flmrqDX0q9vIVt1Lu4ch81cBuql8pHLRNQ=="
+        "resolved": "5.6.0",
+        "contentHash": "5C761AldXHPliilRMMmXA3c9ojxYhtIvFZ21RYBuT9E3tVQUO51WIVfHpDpyArvoaSMKfe/qXZNG4toeE9K/Qw=="
       },
       "Maa.Framework.Runtime.osx-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "ehuruYY/P2cEdJGJTIeHN+HoamBdHYitBr95ycsou9ZViE6m+B1nSkOXbJkRx8TBhS7lXx8Ac9gg7B8DT1C/Aw=="
+        "resolved": "5.6.0",
+        "contentHash": "tMr6B3uNlD/dbjfC8Ac9VQWE2xJfTHQyqAIyD5HWxam6qiFjcsa1JVj53gMhf9d8+HXjx1iSmCIVIP57Mvxw4w=="
       },
       "Maa.Framework.Runtime.osx-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "izClNttn4fk3/DL2ghhsTUd54IVmPICG9Y8vTgz53NCWseUaCdnHc7wfTQzAc7M2pKg/VAJgAdpnlOnASdR3nA=="
+        "resolved": "5.6.0",
+        "contentHash": "DJFamv6Xd3DgGQg/Oig6iBLLwFVpK38Dp50CnKR7WdppnC08tq57wQuykqQOapUm/oGmLRgO8O2mlOSGcUSWkg=="
       },
       "Maa.Framework.Runtime.win-arm64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "72VOu72hShs5M2Jb13jEs5ZXHhs7otRPYVbZU9oHq5jOstiLfILoqOo8FNTml+mR1/zdaKws8ftEymBOKwJ0fg=="
+        "resolved": "5.6.0",
+        "contentHash": "vkANhfQVJJohKjgHWrFa32WDlL6OrahmvZaFquH+kvuSxihfNDS5E578iEPp012eH5DAtZYnE/KegPwcY7zuQw=="
       },
       "Maa.Framework.Runtime.win-x64": {
         "type": "Transitive",
-        "resolved": "5.4.3",
-        "contentHash": "y1BhwWDbpO5vDdMnUhXCkEPx/qmu30xHtSZVoUovnNR1IWuLuf5RP78SC9HoXcnQh67V2xc9BVoLFdOkCPJecA=="
+        "resolved": "5.6.0",
+        "contentHash": "kF8895AF7im/WjsHXFUORhWub7kW4YxfS6yQ782O+YcKnTW4kYhWW2ZT4WtDI4M3SH8bcyTI5gyrZZUk7fTN2g=="
       },
       "Maa.Framework.Binding": {
         "type": "Project"


### PR DESCRIPTION
## Summary by Sourcery

为 MaaFramework v5.6.0 的新特性添加新的 C# 绑定，包括基于 TCP 的代理客户端创建以及“等待画面冻结”的上下文操作。

New Features:
- 引入 `MaaAgentClient` 构造函数和工厂方法，用于通过 TCP 创建代理客户端，并可配置端口以支持仅资源模式和基于 tasker 的配置。
- 暴露 `IMaaContext.WaitFreezes` 的重载方法，以 `TimeSpan` 或毫秒时长的方式等待屏幕稳定，并支持可配置的 JSON 参数。

Enhancements:
- 通过在创建失败时抛出异常以及对必需参数进行空值检查，来校验原生 `MaaAgentClient` 和 `MaaContext` 句柄。
- 在 `MaaAgentClient` 创建 API 的 XML 文档中进一步澄清关于回调转发行为的说明。

Documentation:
- 更新包装层到原生层 API 映射文档，加入 `MaaContext.WaitFreezes` 和 `MaaAgentClient.CreateTcp` 相关绑定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new C# bindings for MaaFramework v5.6.0 features, including TCP-based agent client creation and a context wait-for-freeze operation.

New Features:
- Introduce MaaAgentClient constructors and factory methods for creating agent clients over TCP with configurable ports for resource-only and tasker-based setups.
- Expose IMaaContext.WaitFreezes overloads to wait for screen stabilization using either TimeSpan or millisecond durations and configurable JSON parameters.

Enhancements:
- Validate native MaaAgentClient and MaaContext handles by throwing when creation fails and null-checking required arguments.
- Clarify XML documentation about callback forwarding behavior in MaaAgentClient creation APIs.

Documentation:
- Update wrapper-to-native API mapping documentation to include MaaContext.WaitFreezes and MaaAgentClient.CreateTcp bindings.

</details>