### PR TITLE
fix: wlroots use_win32_vk_code method signature

### DIFF
--- a/src/MaaFramework.Binding.Native/Interop/Framework/Instance/MaaController.cs
+++ b/src/MaaFramework.Binding.Native/Interop/Framework/Instance/MaaController.cs
@@ -113,7 +113,7 @@ public static partial class MaaController
     public static partial MaaControllerHandle MaaPlayCoverControllerCreate(string address, string uuid);
 
     [LibraryImport("MaaFramework", StringMarshalling = StringMarshalling.Utf8)]
-    public static partial MaaControllerHandle MaaWlRootsControllerCreate(string wlr_socket_path);
+    public static partial MaaControllerHandle MaaWlRootsControllerCreate(string wlr_socket_path, [MarshalAs(UnmanagedType.I1)] bool use_win32_vk_code);
 
     /// <summary>
     ///     Create a virtual gamepad controller for Windows.

--- a/src/MaaFramework.Binding.Native/MaaController/MaaWlRootsController.cs
+++ b/src/MaaFramework.Binding.Native/MaaController/MaaWlRootsController.cs
@@ -12,18 +12,23 @@ public class MaaWlRootsController : MaaController
 {
 #pragma warning disable IDE0032 // 使用自动属性
     private readonly string _debugWlrSocketPath;
+    private readonly bool _debugUseWin32VkCode;
 #pragma warning restore IDE0032 // 使用自动属性
 
     [ExcludeFromCodeCoverage(Justification = "Debugger display.")]
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => IsInvalid
         ? $"Invalid {GetType().Name}"
-        : $"{GetType().Name} {{ WlrSocketPath = {_debugWlrSocketPath} }}";
+        : $"{GetType().Name} {{ WlrSocketPath = {_debugWlrSocketPath}, UseWin32VkCode = {_debugUseWin32VkCode} }}";
 
     /// <summary>
     ///     Creates a <see cref="MaaWlRootsController"/> instance.
     /// </summary>
     /// <param name="wlrSocketPath">The wayland socket path (e.g., "/run/user/1000/wayland-0").</param>
+    /// <param name="useWin32VkCode">If true, key codes passed to click_key / key_down / key_up are
+    /// interpreted as Win32 Virtual-Key codes (VK_*) and translated to Linux evdev codes
+    /// internally. If false, key codes are passed through as raw evdev codes.
+    /// </param>
     /// <param name="link">Executes <see cref="IMaaController.LinkStart"/> if <see cref="LinkOption.Start"/>; otherwise, not link.</param>
     /// <param name="check">Checks LinkStart().Wait() status if <see cref="CheckStatusOption.ThrowIfNotSucceeded"/>; otherwise, not check.</param>
     /// <remarks>
@@ -32,15 +37,16 @@ public class MaaWlRootsController : MaaController
     /// </remarks>
     /// <exception cref="ArgumentException"/>
     /// <exception cref="MaaJobStatusException"/>
-    public MaaWlRootsController(string wlrSocketPath, LinkOption link = LinkOption.Start, CheckStatusOption check = CheckStatusOption.ThrowIfNotSucceeded)
+    public MaaWlRootsController(string wlrSocketPath, bool useWin32VkCode = false, LinkOption link = LinkOption.Start, CheckStatusOption check = CheckStatusOption.ThrowIfNotSucceeded)
     {
         ArgumentException.ThrowIfNullOrEmpty(wlrSocketPath);
 
-        var handle = MaaWlRootsControllerCreate(wlrSocketPath);
+        var handle = MaaWlRootsControllerCreate(wlrSocketPath, useWin32VkCode);
         _ = MaaControllerAddSink(handle, MaaEventCallback, (nint)MaaHandleType.Controller);
         SetHandle(handle, needReleased: true);
 
         _debugWlrSocketPath = wlrSocketPath;
+        _debugUseWin32VkCode = useWin32VkCode;
 
         if (link == LinkOption.Start)
             LinkStartOnConstructed(check, wlrSocketPath);


### PR DESCRIPTION
## Summary by Sourcery

更新 WlRoots 控制器的创建逻辑，接受并传递用于按键输入转换的 Win32 虚拟键模式标志。

新功能：
- 为 `MaaWlRootsController` 新增可选参数 `useWin32VkCode`，用于控制按键码是按 Win32 虚拟键码还是按原始 evdev 码进行解释。

错误修复：
- 通过添加 `use_win32_vk_code` 布尔参数，使 `MaaWlRootsControllerCreate` 的 P/Invoke 签名与原生 API 对齐。

增强项：
- 扩展 `MaaWlRootsController` 的调试器显示内容，包含 `UseWin32VkCode` 标志，以提升调试可见性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update WlRoots controller creation to accept and propagate a Win32 virtual-key mode flag for key input translation.

New Features:
- Add an optional useWin32VkCode parameter to MaaWlRootsController to control interpretation of key codes as Win32 virtual-key codes or raw evdev codes.

Bug Fixes:
- Align the MaaWlRootsControllerCreate P/Invoke signature with the native API by adding the use_win32_vk_code boolean parameter.

Enhancements:
- Extend MaaWlRootsController debugger display to include the UseWin32VkCode flag for improved debugging visibility.

</details>